### PR TITLE
feat: improved type inference for callback parameters

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 export default function doublet<Arg, R>(cb: Callback<Arg, R>, ...args: Array<Arg>): Result<R> | Promise<Result<R>> {
   try {
-    const result: R = cb(...args);
+    const result = cb(...args);
 
     if (result instanceof Promise) {
       return result

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,11 +5,11 @@ export default function doublet<Arg, R>(cb: Callback, ...args: Array<Arg>): Resu
     if (result instanceof Promise) {
       return result
         .then((rx) => [null, rx])
-        .catch((error) => [error]) as Promise<Result<R>>;
+        .catch((error) => [error, null]) as Promise<Result<R>>;
     }
 
     return [null, result];
   } catch (error) {
-    return [error];
+    return [error, null];
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,15 +1,15 @@
-export default function doublet<Arg, R>(cb: Callback<Arg, R>, ...args: Array<Arg>): Result<R> | Promise<Result<R>> {
+export default function doublet<Arg, R>(cb: Callback<Arg, R>, ...args: Array<Arg>): MaybeAsyncResult<R> {
   try {
     const result = cb(...args);
 
     if (result instanceof Promise) {
       return result
         .then((rx) => [null, rx])
-        .catch((error) => [error, null]) as Promise<Result<R>>;
+        .catch((error) => [error, null]) as MaybeAsyncResult<R>;
     }
 
-    return [null, result];
+    return [null, result] as MaybeAsyncResult<R>;
   } catch (error) {
-    return [error, null];
+    return [error, null] as MaybeAsyncResult<R>;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export default function doublet<Arg, R>(cb: Callback, ...args: Array<Arg>): Result<R> | Promise<Result<R>> {
+export default function doublet<Arg, R>(cb: Callback<Arg, R>, ...args: Array<Arg>): Result<R> | Promise<Result<R>> {
   try {
     const result: R = cb(...args);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,15 +1,15 @@
-export default function doublet<Arg, R>(cb: Callback<Arg, R>, ...args: Array<Arg>): MaybeAsyncResult<R> {
+export default function doublet<TCallback extends Callback>(cb: TCallback, ...args: Parameters<TCallback>): MaybeAsyncResult<ReturnType<TCallback>> {
   try {
-    const result = cb(...args);
+    const result = cb(...args as Array<unknown>);
 
     if (result instanceof Promise) {
       return result
         .then((rx) => [null, rx])
-        .catch((error) => [error, null]) as MaybeAsyncResult<R>;
+        .catch((error) => [error, null]) as MaybeAsyncResult<ReturnType<TCallback>>;
     }
 
-    return [null, result] as MaybeAsyncResult<R>;
+    return [null, result] as MaybeAsyncResult<ReturnType<TCallback>>;
   } catch (error) {
-    return [error, null] as MaybeAsyncResult<R>;
+    return [error, null] as MaybeAsyncResult<ReturnType<TCallback>>;
   }
 }

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -23,7 +23,7 @@ describe('given a synchronous function', () => {
       const [error, result] = doublet(thatFails);
 
       expect(error).toEqual(Error('failed'));
-      expect(result).toBeUndefined();
+      expect(result).toBeNull();
     });
   });
 });
@@ -49,9 +49,9 @@ describe('given an asynchronous function', () => {
         throw new Error(result);
       }
 
-      expect(doublet(thatFails, 'abc', 'def', 'ghi')).resolves.toStrictEqual([
-        Error('failed'),
-      ]);
+      expect(doublet(thatFails, 'abc', 'def', 'ghi')).resolves.toStrictEqual(
+        [Error('failed'), null],
+      );
     });
   });
 });
@@ -76,7 +76,7 @@ describe('given an function that returns a promise', () => {
       }
 
       expect(doublet(thatFails, 'abc', 'def', 'ghi')).resolves.toStrictEqual(
-        [Error('failed')],
+        [Error('failed'), null],
       );
     });
   });

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,5 +1,3 @@
 type Result<R> = [Error, null] | [null, R];
 
-interface Callback {
-  <Arg, R>(...a: Array<Arg>): R
-}
+type Callback<Arg, R> = (...args: Array<Arg>) => R;

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,5 +1,5 @@
 type Result<R> = [Error, null] | [null, R];
 
-type Callback<Arg, R> = (...args: Array<Arg>) => R;
+type Callback = (...args: any) => any;
 
 type MaybeAsyncResult<R> = R extends Promise<infer U> ? Promise<Result<U>> : Result<R>

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,3 +1,6 @@
 type Result<R> = [Error, null] | [null, R];
 
 type Callback<Arg, R> = (...args: Array<Arg>) => R;
+
+type MaybeAsyncResult<R> = R extends Promise<infer U> ? Promise<Result<U>> : Result<R>
+

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,4 +1,4 @@
-type Result<R> = [Error | null, R?];
+type Result<R> = [Error, null] | [null, R];
 
 interface Callback {
   <Arg, R>(...a: Array<Arg>): R


### PR DESCRIPTION
This PR brings better TS inference for the callback parameters via the `Parameters<T>` type which constructs a tuple from the arguments instead of a plain Array.

Before:

```typescript
function tryMe(arg1: string, arg2: number, arg3: Date) {
  // ...
}

const [error, result] = doublet(tryMe, 'bonjour', 10, new Date()); // Here the type ...args was `(string | number | Date)[]` meaning you could place them in any order which is not wanted.
```

Now: 

```typescript
function tryMe(arg1: string, arg2: number, arg3: Date) {
  // ...
}

const [error, result] = doublet(tryMe, 'bonjour', 10, new Date()); // Here the type ...args is `[string, number, Date]` and TS will warn if the types don't match the positions. 
```