### PR TITLE
fix: refined `Promise` detection logic to account for alternate implementations

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,20 @@
-export default function doublet<TCallback extends Callback>(cb: TCallback, ...args: Parameters<TCallback>): MaybeAsyncResult<ReturnType<TCallback>> {
-  try {
-    const result = cb(...args as Array<unknown>);
+function isPromiseLike(x: unknown): x is Promise<unknown> {
+  return x != null
+    && typeof x === 'object'
+    && 'then' in x
+    && typeof (x as { then: unknown }).then === 'function'
+    && 'catch' in x
+    && typeof (x as { catch: unknown }).catch === 'function';
+}
 
-    if (result instanceof Promise) {
+export default function doublet<TCallback extends Callback>(
+  cb: TCallback,
+  ...args: Parameters<TCallback>
+): MaybeAsyncResult<ReturnType<TCallback>> {
+  try {
+    const result = cb(...(args as Array<unknown>));
+
+    if (isPromiseLike(result)) {
       return result
         .then((rx) => [null, rx])
         .catch((error) => [error, null]) as MaybeAsyncResult<ReturnType<TCallback>>;


### PR DESCRIPTION
## Description

This PR aims to fix bugs when using this library with third-party modules which either wrap the native `Promise` object or declare alternative implementations altogether. Due to the way we currently handle `Promise` detection, the latter case would fail that check and be treated as a synchronous value and unexpectedly throw instead of being handled by `doublet`.

See https://stackoverflow.com/a/27746324

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

**Test Configuration**:
* Node version: 16.16.0
* Operating System: Darwin Kernel Version 21.6.0

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
